### PR TITLE
Fix invalid parameter in about page

### DIFF
--- a/views/about_me.py
+++ b/views/about_me.py
@@ -6,7 +6,7 @@ def show_contact_form():
     contact_form()
 
 # --- HERO SECTION ---
-col1, col2 = st.columns(2, gap="small", vertical_alignment="center")
+col1, col2 = st.columns(2, gap="small")
 with col1:
     st.image("./assets/profile_image.png", width=230)
 


### PR DESCRIPTION
## Summary
- remove incorrect `vertical_alignment` parameter when building the columns on the about page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68730869103c83318ed61c66998cd6cb